### PR TITLE
プロフィール登録画面の追加

### DIFF
--- a/src/app/api/user/user.service.spec.ts
+++ b/src/app/api/user/user.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(UserService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/api/user/user.service.ts
+++ b/src/app/api/user/user.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+
+import { ConnectService } from '../connect.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UserService extends ConnectService {
+  basePath: string = this.basePath + '/api/users';
+}

--- a/src/app/shared/firestore.service.ts
+++ b/src/app/shared/firestore.service.ts
@@ -34,6 +34,7 @@ export class FirestoreService {
     this.userDoc = doc(this.af, `users/${uid}`);
     return docData(this.userDoc).pipe(first()).toPromise(Promise);
   }
+
   userSet(user: IUser): Promise<void> {
     return setDoc(this.userDoc, user);
   }

--- a/src/app/shared/profile/profile-routing.module.ts
+++ b/src/app/shared/profile/profile-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { ProfilePage } from './profile.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ProfilePage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ProfilePageRoutingModule {}

--- a/src/app/shared/profile/profile.page.html
+++ b/src/app/shared/profile/profile.page.html
@@ -1,0 +1,38 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-button (click)="modalDismiss()">
+        <ion-icon name="close" slot="icon-only"></ion-icon>
+      </ion-button>
+    </ion-buttons>
+    <ion-title>プロフィール</ion-title>
+    <ion-buttons slot="end">
+      <ion-button (click)="updateProfile()" [disabled]="!f.form.valid || (!photo && !this.user.photoDataUrl)">
+        登録
+      </ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <div class="ion-text-center ion-padding">
+    <ion-avatar style="display: inline-block">
+      <img [src]="photo || user.photoDataUrl || '/assets/shapes.svg'" />
+    </ion-avatar>
+  </div>
+  <!-- <div class="ion-text-center">
+    <ion-button (click)="takePicture()" fill="clear" size="small"> 画像変更 </ion-button>
+  </div> -->
+  <form #f="ngForm">
+    <ion-list class="ion-padding">
+      <ion-item>
+        <ion-label position="floating">ユーザID</ion-label>
+        <ion-input type="text" [value]="uid" disabled=""></ion-input>
+      </ion-item>
+      <ion-item>
+        <ion-label position="floating">表示名</ion-label>
+        <ion-input type="text" [(ngModel)]="user.displayName" name="displayName" required></ion-input>
+      </ion-item>
+    </ion-list>
+  </form>
+</ion-content>

--- a/src/app/shared/profile/profile.page.spec.ts
+++ b/src/app/shared/profile/profile.page.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+
+import { ProfilePage } from './profile.page';
+
+describe('ProfilePage', () => {
+  let component: ProfilePage;
+  let fixture: ComponentFixture<ProfilePage>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProfilePage],
+      imports: [IonicModule.forRoot()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProfilePage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/profile/profile.page.ts
+++ b/src/app/shared/profile/profile.page.ts
@@ -1,0 +1,54 @@
+import { Component, OnInit } from '@angular/core';
+import { ModalController } from '@ionic/angular';
+//import { Camera, CameraResultType } from '@capacitor/camera';
+
+import { FirestoreService, IUser } from '../firestore.service';
+import { AuthService } from '../../auth/auth.service';
+
+@Component({
+  selector: 'app-profile',
+  templateUrl: './profile.page.html',
+  styleUrls: ['./profile.page.scss'],
+})
+export class ProfilePage implements OnInit {
+  uid: string;
+  user: IUser = {
+    displayName: null,
+    photoDataUrl: 'https://www.seekpng.com/png/detail/385-3852777_ionic-icon-png.png',
+  };
+  photo: string;
+
+  constructor(public modalController: ModalController, public auth: AuthService, public firestore: FirestoreService) {}
+
+  ngOnInit() {}
+
+  async ionViewWillEnter() {
+    this.uid = await this.auth.getUserId();
+    const user = await this.firestore.userInit(this.uid);
+    if (user) {
+      this.user = user;
+    }
+  }
+
+  async updateProfile() {
+    if (this.photo) {
+      this.user.photoDataUrl = this.photo;
+    }
+    await this.firestore.userSet(this.user);
+    this.modalController.dismiss();
+  }
+
+  modalDismiss() {
+    this.modalController.dismiss();
+  }
+
+  // TODO: 写真を任意に登録できるようにする
+  /* async takePicture() {
+    const image = await Camera.getPhoto({
+      quality: 90,
+      resultType: CameraResultType.DataUrl,
+    });
+
+    this.photo = image && image.dataUrl;
+  } */
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ProfilePage } from './profile/profile.page';
+import { FormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+
+@NgModule({
+  declarations: [ProfilePage],
+  imports: [CommonModule, FormsModule, IonicModule],
+})
+export class SharedModule {}

--- a/src/app/tabs/home/home.module.ts
+++ b/src/app/tabs/home/home.module.ts
@@ -5,9 +5,10 @@ import { FormsModule } from '@angular/forms';
 import { HomePage } from './home.page';
 
 import { HomePageRoutingModule } from './home-routing.module';
+import { SharedModule } from '../../shared/shared.module';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, IonicModule, HomePageRoutingModule],
+  imports: [CommonModule, FormsModule, IonicModule, HomePageRoutingModule, SharedModule],
   declarations: [HomePage],
 })
 export class HomePageModule {}

--- a/src/app/tabs/home/home.page.ts
+++ b/src/app/tabs/home/home.page.ts
@@ -1,4 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ModalController } from '@ionic/angular';
+
+import { ProfilePage } from '../../shared/profile/profile.page';
+import { UserService } from 'src/app/api/user/user.service';
+import { AuthService } from '../../auth/auth.service';
 
 @Component({
   selector: 'app-home',
@@ -6,6 +11,25 @@ import { Component } from '@angular/core';
   styleUrls: ['home.page.scss'],
 })
 export class HomePage {
-  title: string = 'ホーム';
-  constructor() {}
+  title = 'ホーム';
+  uid: string;
+  private users;
+  constructor(private auth: AuthService, private userService: UserService, public modalController: ModalController) {}
+
+  async ionViewDidEnter(): Promise<void> {
+    this.uid = await this.auth.getUserId();
+    this.userService.getList().subscribe(async (response) => {
+      this.users = response;
+      if (this.users.length) {
+        const uids = this.users.filter((user) => user.id === this.uid);
+        if (uids.length) {
+          return;
+        }
+      }
+      const modal = await this.modalController.create({
+        component: ProfilePage,
+      });
+      await modal.present();
+    });
+  }
 }

--- a/src/app/tabs/settings/settings.page.html
+++ b/src/app/tabs/settings/settings.page.html
@@ -7,7 +7,7 @@
 <ion-content>
   <ion-list>
     <ion-item button="true" *ngFor="let content of contents" (click)="action_router(content.action)">
-      <ion-icon name="{{ content.icon }}"></ion-icon>
+      <ion-icon slot="start" name="{{ content.icon }}"></ion-icon>
       <ion-label>{{ content.label }}</ion-label>
     </ion-item>
   </ion-list>


### PR DESCRIPTION
firestore上のusersコレクションにデータが登録されていない場合、プロフィール登録モーダルが表示され、プロフィール登録ができる

ホーム画面でモーダルが都度表示される。