### PR TITLE
日常登録画面で曜日選択を楽に、気を楽に

### DIFF
--- a/src/app/tabs/usual/components/ordinary-modal/ordinary-modal.component.html
+++ b/src/app/tabs/usual/components/ordinary-modal/ordinary-modal.component.html
@@ -11,30 +11,52 @@
   <form>
     <ion-item>
       <ion-label position="floating">日常名</ion-label>
-      <ion-input placeholder="歯を磨く" name="ordinary_name" [(ngModel)]="ordinary.name" required="true"></ion-input>
+      <ion-input placeholder="歯を磨く" name="ordinaryName" [(ngModel)]="ordinary.name" required="true"></ion-input>
     </ion-item>
 
-    <ion-grid fixed>
-      <ion-list-header>
-        <h3>実施する曜日</h3>
-      </ion-list-header>
-      <ion-list>
-        <ion-item *ngFor="let weekday of weekdays">
-          <ion-label>{{ weekday.name }}</ion-label>
-          <ion-checkbox slot="start" [(ngModel)]="weekday.isChecked" name="weekdays"></ion-checkbox>
-        </ion-item>
-      </ion-list>
+    <ion-list-header>
+      <h3>実施曜日</h3>
+    </ion-list-header>
+    <ion-segment [(ngModel)]="scene" [ngModelOptions]="{ standalone: true }">
+      <ion-segment-button [value]="s.scene" *ngFor="let s of scenes">
+        <ion-label>{{ s.name }}</ion-label>
+      </ion-segment-button>
+    </ion-segment>
+
+    <div [ngSwitch]="scene">
+      <ng-container *ngFor="let s of scenes">
+        <div *ngSwitchCase="s.scene">
+          <ng-container *ngIf="s.scene === 'day'">
+            <ion-list>
+              <ion-item *ngFor="let weekday of weekdays">
+                <ion-label>
+                  {{ weekday.name }}
+                </ion-label>
+                <ion-checkbox
+                  slot="start"
+                  [(ngModel)]="weekday.isChecked"
+                  [ngModelOptions]="{ standalone: true }"
+                ></ion-checkbox>
+              </ion-item>
+            </ion-list>
+          </ng-container>
+        </div>
+      </ng-container>
+    </div>
+
+    <ion-list-header>
       <h3>日常開始日</h3>
-      <ion-datetime
-        size="cover"
-        presentation="date"
-        [(ngModel)]="usersOrdinary.startedOn"
-        displayFormat="yyyy-MM-dd"
-        pickerFormat="yyyy-MM-dd"
-        min="{{ now }}"
-        name="startedOn"
-      ></ion-datetime>
-    </ion-grid>
+    </ion-list-header>
+    <ion-datetime
+      size="cover"
+      presentation="date"
+      [(ngModel)]="usersOrdinary.startedOn"
+      [ngModelOptions]="{ standalone: true }"
+      displayFormat="yyyy-MM-dd"
+      pickerFormat="yyyy-MM-dd"
+      min="{{ now }}"
+      name="startedOn"
+    ></ion-datetime>
   </form>
 
   <ion-button expand="block" (click)="onCreateOrdinary()">

--- a/src/app/tabs/usual/components/ordinary-modal/ordinary-modal.component.ts
+++ b/src/app/tabs/usual/components/ordinary-modal/ordinary-modal.component.ts
@@ -15,6 +15,9 @@ export class OrdinaryModalComponent implements OnInit {
   @Input() weekdays;
   @Input() usersOrdinary;
   @Input() achievements;
+  scenes;
+
+  scene;
 
   constructor(
     private modalController: ModalController,
@@ -25,9 +28,39 @@ export class OrdinaryModalComponent implements OnInit {
   ngOnInit() {
     this.usersOrdinary.startedOn = format(this.usersOrdinary.startedOn, 'YYYY-MM-DD');
     this.now = format(this.now, 'YYYY-MM-DD');
+    this.scene = this.scenes[0].scene;
+    this.scenes = [
+      { scene: 'everyday', name: '毎日' },
+      { scene: 'weekday', name: '平日' },
+      { scene: 'weekend', name: '土日' },
+      { scene: 'day', name: '曜日' },
+    ];
   }
 
   async onCreateOrdinary() {
+    if (this.scene === 'everyday') {
+      this.weekdays = await this.weekdays.map((weekday) => {
+        return {
+          ...weekday,
+          isChecked: true,
+        };
+      });
+    } else if (this.scene === 'weekday') {
+      this.weekdays = await this.weekdays.map((weekday) => {
+        return {
+          ...weekday,
+          isChecked: true ? [1, 2, 3, 4, 5].indexOf(weekday.order) !== -1 : false,
+        };
+      });
+    } else if (this.scene === 'weekend') {
+      this.weekdays = await this.weekdays.map((weekday) => {
+        return {
+          ...weekday,
+          isChecked: true ? [6, 7].indexOf(weekday.order) !== -1 : false,
+        };
+      });
+    }
+
     this.achievements = await this.usersOrdinaryService.createUesrsOrdinaries(
       this.user,
       this.ordinary,

--- a/src/app/tabs/usual/usual.page.ts
+++ b/src/app/tabs/usual/usual.page.ts
@@ -188,6 +188,7 @@ export class UsualPage {
         weekdays: this.weekdays,
         usersOrdinary: this.usersOrdinary,
         achievements: this.achievements,
+        scenes: this.scenes,
       },
     });
 


### PR DESCRIPTION
#16 対応

- 従来
  - 曜日選択が全てチェックボックスだった
- 改善
  - 「毎日」・「平日」・「土日」・「曜日」のセグメントに分けた
  - 毎日：月〜日が自動的に割り当てられる
  - 平日：月〜金が
  - 土日：土〜日が
  - 曜日：チェックボックスで選択する画面が動的に表示
